### PR TITLE
Replace recursive dispatch_after with UIView animation API

### DIFF
--- a/SwiftCharts/Layers/ChartPointsLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsLayer.swift
@@ -24,7 +24,7 @@ public class ChartPointsLayer<T: ChartPoint>: ChartCoordsSpaceLayer {
 
     let chartPointsModels: [ChartPointLayerModel<T>]
     
-    private let displayDelay: Float
+    public let displayDelay: Float
     
     public var chartPointScreenLocs: [CGPoint] {
         return self.chartPointsModels.map{$0.screenLoc}
@@ -43,13 +43,7 @@ public class ChartPointsLayer<T: ChartPoint>: ChartCoordsSpaceLayer {
 
 
     override public func chartInitialized(#chart: Chart) {
-        if self.displayDelay == 0 {
-            self.display(chart: chart)
-        } else {
-            dispatch_after(ChartUtils.toDispatchTime(self.displayDelay), dispatch_get_main_queue()) {() -> Void in
-                self.display(chart: chart)
-            }
-        }
+        self.display(chart: chart)
     }
     
     func display(#chart: Chart) {}

--- a/SwiftCharts/Layers/ChartPointsViewsLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsViewsLayer.swift
@@ -32,23 +32,14 @@ public class ChartPointsViewsLayer<T: ChartPoint, U: UIView>: ChartPointsLayer<T
         super.display(chart: chart)
         
         self.viewsWithChartPoints = self.generateChartPointViews(chartPointModels: self.chartPointsModels, chart: chart)
-        
-        if self.delayBetweenItems == 0 {
-            for v in self.viewsWithChartPoints {chart.addSubview(v.view)}
-            
-        } else {
-            var next: (Int, dispatch_time_t) -> () = {_, _ in} // no-op closure, workaround for local recursive function. See http://stackoverflow.com/a/24272256
-            next = {index, delay in
-                if index < self.viewsWithChartPoints.count {
-                    dispatch_after(delay, dispatch_get_main_queue()) {() -> Void in
-                        let view = self.viewsWithChartPoints[index].view
-                        chart.addSubview(view)
-                        
-                        next(index + 1, ChartUtils.toDispatchTime(self.delayBetweenItems))
-                    }
-                }
-            }
-            next(0, 0)
+
+        for (index, viewWithChartPoint) in enumerate(self.viewsWithChartPoints) {
+            var view = viewWithChartPoint.view
+            view.alpha = 0
+            chart.addSubview(view)
+            UIView.animateWithDuration(0, delay: NSTimeInterval(self.displayDelay) + NSTimeInterval(index) * NSTimeInterval(self.delayBetweenItems), options: .BeginFromCurrentState, animations: {
+                view.alpha = 1
+            }, completion: nil)
         }
     }
     


### PR DESCRIPTION
Recursive dispatch_after seems a bit too clever and also prevents cancellation of the block before it gets executed. Instead, we can use the UIView animation APIs to do this since it's view-related and it also allows us to cancel all of the chart animations (it has a zero duration but _could_ be animated) before it starts with `chart.view.layer.removeAllAnimations()`.
