### PR TITLE
Add support for using a plain grouped bar view generation closure

### DIFF
--- a/SwiftCharts/Layers/ChartBarsLayer.swift
+++ b/SwiftCharts/Layers/ChartBarsLayer.swift
@@ -38,9 +38,12 @@ class ChartBarsViewGenerator<T: ChartBarModel> {
     let chartInnerFrame: CGRect
     let direction: ChartBarDirection
     let barWidth: CGFloat
-    
-    init(horizontal: Bool, xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, chartInnerFrame: CGRect, barWidth barWidthMaybe: CGFloat?, barSpacing barSpacingMaybe: CGFloat?) {
-        
+
+    typealias ViewGeneratorClosure = (barModel: T, viewPoints: (CGPoint, CGPoint), barWidth: CGFloat, bgColor: UIColor?) -> ChartPointViewBar
+    var viewGenerator: ViewGeneratorClosure?
+
+    init(horizontal: Bool, xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, chartInnerFrame: CGRect, barWidth barWidthMaybe: CGFloat?, barSpacing barSpacingMaybe: CGFloat?, viewGenerator: ViewGeneratorClosure? = nil) {
+
         let direction: ChartBarDirection = {
             switch (horizontal: horizontal, yLow: yAxis.low, xLow: xAxis.low) {
             case (horizontal: true, yLow: true, _): return .LeftToRight
@@ -55,7 +58,7 @@ class ChartBarsViewGenerator<T: ChartBarModel> {
                 case .LeftToRight: return yAxis
                 case .BottomToTop: return xAxis
                 }
-                }()
+            }()
             let spacing: CGFloat = barSpacingMaybe ?? 0
             return axis.minAxisScreenSpace - spacing
         }()
@@ -65,6 +68,7 @@ class ChartBarsViewGenerator<T: ChartBarModel> {
         self.chartInnerFrame = chartInnerFrame
         self.direction = direction
         self.barWidth = barWidth
+        self.viewGenerator = viewGenerator
     }
     
     func viewPoints(barModel: T, constantScreenLoc: CGFloat) -> (p1: CGPoint, p2: CGPoint) {
@@ -90,6 +94,10 @@ class ChartBarsViewGenerator<T: ChartBarModel> {
         let constantScreenLoc = constantScreenLocMaybe ?? self.constantScreenLoc(barModel)
         
         let viewPoints = self.viewPoints(barModel, constantScreenLoc: constantScreenLoc)
+
+        if let viewGenerator = viewGenerator {
+            return viewGenerator(barModel: barModel, viewPoints: viewPoints, barWidth: barWidth, bgColor: bgColor)
+        }
         return ChartPointViewBar(p1: viewPoints.p1, p2: viewPoints.p2, width: self.barWidth, bgColor: bgColor, animDuration: animDuration)
     }
 }

--- a/SwiftCharts/Layers/ChartGroupedBarsLayer.swift
+++ b/SwiftCharts/Layers/ChartGroupedBarsLayer.swift
@@ -84,13 +84,16 @@ public class ChartGroupedBarsLayer<T: ChartBarModel>: ChartCoordsSpaceLayer {
 
 public typealias ChartGroupedPlainBarsLayer = ChartGroupedPlainBarsLayer_<Any>
 public class ChartGroupedPlainBarsLayer_<N>: ChartGroupedBarsLayer<ChartBarModel> {
+    public typealias ViewGeneratorClosure = (barModel: ChartBarModel, viewPoints: (CGPoint, CGPoint), barWidth: CGFloat, bgColor: UIColor?) -> ChartPointViewBar
+    var viewGenerator: ViewGeneratorClosure?
 
-    public override init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, groups: [ChartPointsBarGroup<ChartBarModel>], horizontal: Bool, barSpacing: CGFloat?, groupSpacing: CGFloat?, animDuration: Float) {
+    public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, groups: [ChartPointsBarGroup<ChartBarModel>], horizontal: Bool, barSpacing: CGFloat?, groupSpacing: CGFloat?, animDuration: Float, viewGenerator: ViewGeneratorClosure? = nil) {
+        self.viewGenerator = viewGenerator
         super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, groups: groups, horizontal: horizontal, barSpacing: barSpacing, groupSpacing: groupSpacing, animDuration: animDuration)
     }
-    
+
     override func barsGenerator(barWidth barWidth: CGFloat) -> ChartBarsViewGenerator<ChartBarModel> {
-        return ChartBarsViewGenerator(horizontal: self.horizontal, xAxis: self.xAxis, yAxis: self.yAxis, chartInnerFrame: self.innerFrame, barWidth: barWidth, barSpacing: self.barSpacing)
+        return ChartBarsViewGenerator(horizontal: self.horizontal, xAxis: self.xAxis, yAxis: self.yAxis, chartInnerFrame: self.innerFrame, barWidth: barWidth, barSpacing: self.barSpacing, viewGenerator: viewGenerator)
     }
 }
 

--- a/SwiftCharts/Layers/ChartStackedBarsLayer.swift
+++ b/SwiftCharts/Layers/ChartStackedBarsLayer.swift
@@ -36,8 +36,8 @@ public class ChartStackedBarModel: ChartBarModel {
 class ChartStackedBarsViewGenerator<T: ChartStackedBarModel>: ChartBarsViewGenerator<T> {
     
     private typealias FrameBuilder = (barModel: ChartStackedBarModel, item: ChartStackedBarItemModel, currentTotalQuantity: Double) -> (frame: ChartPointViewBarStackedFrame, length: CGFloat)
-    
-    override init(horizontal: Bool, xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, chartInnerFrame: CGRect, barWidth barWidthMaybe: CGFloat?, barSpacing barSpacingMaybe: CGFloat?) {
+
+    init(horizontal: Bool, xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, chartInnerFrame: CGRect, barWidth barWidthMaybe: CGFloat?, barSpacing barSpacingMaybe: CGFloat?) {
         super.init(horizontal: horizontal, xAxis: xAxis, yAxis: yAxis, chartInnerFrame: chartInnerFrame, barWidth: barWidthMaybe, barSpacing: barSpacingMaybe)
     }
     


### PR DESCRIPTION
This adds the ability to give the grouped bar layer a bar-generating closure, similar to what is possible with other chart styles. This can allow e.g. making tappable bars in a grouped bar chart.
